### PR TITLE
jp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,55 @@
+# Created by .ignore support plugin (hsz.mobi)
+### C template
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+

--- a/examples/attiny13/main.c
+++ b/examples/attiny13/main.c
@@ -1,35 +1,165 @@
-/**
- * Copyright (c) 2017, Łukasz Marcin Podkalicki <lpodkalicki@gmail.com>
+/* Copyright (c) 2017-2018, Łukasz Marcin Podkalicki <lpodkalicki@gmail.com>
  *
- * This is ATtiny13 "Running Digits" example using attiny-tm1637-library,
- * https://github.com/lpodkalicki/attiny-tm1637-library .
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Some examples of how to use attiny-tm1637-library,
+ * https://github.com/lpodkalicki/attiny-tm1637-library.
  *
  */
 
-#include <stdint.h>
+#define F_CPU 1000000UL
+
+#include <stdio.h>
+#include <stdlib.h>
 #include <avr/io.h>
 #include <util/delay.h>
+
 #include "tm1637.h"
+
+void displayInAllSegments(uint8_t segment);
+void displayTemperature(float t, const char unit);
 
 int
 main(void)
 {
-	uint8_t i = 0;
+	uint8_t j = 0;
 
 	/* setup */
-	TM1637_init();
+	TM1637_init(PB0, PB1);
 
 	/* loop */
-	while (1) {
-		TM1637_display_digit(TM1637_SET_ADR_00H, i % 0x10);
-		TM1637_display_digit(TM1637_SET_ADR_01H, (i + 1) % 0x10);
-		TM1637_display_digit(TM1637_SET_ADR_02H, (i + 2) % 0x10);
-		TM1637_display_digit(TM1637_SET_ADR_03H, (i + 3) % 0x10);
-		TM1637_display_colon(true);
-		_delay_ms(200);
-		TM1637_display_colon(false);
-		_delay_ms(200);
-		i++;
-	}
+    while (1) {
+        // This is ATtiny13 "Running Digits" example using attiny-tm1637-library,
+        for (uint8_t i=0; i<200; i++) {
+		    TM1637_display_digit(TM1637_SET_ADR_00H, i % 0x10);
+		    TM1637_display_digit(TM1637_SET_ADR_01H, (i + 1) % 0x10);
+		    TM1637_display_digit(TM1637_SET_ADR_02H, (i + 2) % 0x10);
+		    TM1637_display_digit(TM1637_SET_ADR_03H, (i + 3) % 0x10);
+		    TM1637_display_colon(true);
+		    _delay_ms(200);
+		    TM1637_display_colon(false);
+		    _delay_ms(200);
+		}
+		TM1637_clear();
+        displayInAllSegments(0x1);
+        _delay_ms(200);
+        displayInAllSegments(0x40);
+        _delay_ms(200);
+        displayInAllSegments(0x08);
+        _delay_ms(200);
+        TM1637_clear();
+        _delay_ms(200);
+        // digit numbering from left to right: 0 1 2 3
+        TM1637_display_digit(2, j++ % 10); // digit second from right
+        _delay_ms(2000);
+        TM1637_display_digit(0, j++ % 10); // left most digit
+        _delay_ms(2000);
+        TM1637_display_digit(3, j++ % 10); // right most digit
+        _delay_ms(2000);
+        TM1637_display_digit(1, j++ % 10); // digit second from left
+        _delay_ms(2000);
+        j %= 7; // keep j in range 0 to 6
+        displayInAllSegments(0x08);
+        _delay_ms(200);
+        displayInAllSegments(0x40);
+        _delay_ms(200);
+        displayInAllSegments(0x1);
+        _delay_ms(1000);
+        TM1637_display_text("Error-Error-Error");
+        _delay_ms(1000);
+        TM1637_clear();
+        _delay_ms(500);
+        // switch on colon until disabled again
+        TM1637_display_colon(1);
+        TM1637_display_text("203C");
+        _delay_ms(1000);
+        TM1637_display_text("451H");
+        _delay_ms(2000);
+        displayTemperature(-9.26, 'C');
+        _delay_ms(3000);
+        displayTemperature(29.26, 'F');
+        _delay_ms(3000);
+        displayTemperature(-0.26, 'C');
+        _delay_ms(3000);
+        displayTemperature(100.26, 'C');
+        _delay_ms(3000);
+        // blinking colon
+        TM1637_display_colon(0);
+        TM1637_display_text("291H");
+        _delay_ms(1000);
+        TM1637_display_colon(1);
+        _delay_ms(1000);
+        TM1637_display_colon(0);
+        _delay_ms(1000);
+        TM1637_display_colon(1);
+        _delay_ms(1000);
+        // colon is still switched on
+        TM1637_display_text("HELLO");
+        _delay_ms(3000);
+        // clear display including colon
+        TM1637_clear();
+        _delay_ms(3000);
+        TM1637_display_text("0123456789");
+        _delay_ms(3000);
+    }
 }
-
+        
+void displayInAllSegments(uint8_t segment) {
+    TM1637_display_segments(0, segment);
+    TM1637_display_segments(1, segment);
+    TM1637_display_segments(2, segment);
+    TM1637_display_segments(3, segment);
+}
+        
+void displayTemperature(float t, const char unit) {
+    // range -9.9 degrees Celsius up to 99.9 degress Celsius or Fahrenheit
+    if (t >= -9.9 && t <= 99.9) {
+        TM1637_display_colon(1);
+        
+        uint8_t pos = 0;
+        
+        // position 0 (outer left)
+        if (t < 0) {
+            TM1637_display_segments(pos++, 0x40);
+            t = -t;
+        }
+        int d = 0;
+        if (pos == 0 && t > 10) {
+            d = (int) t / 10;
+            TM1637_display_digit(pos++, d);
+            t = t - d * 10.0;
+        } else if (pos == 0) {
+            TM1637_display_segments(pos++, 0x0);
+        }
+        // position 1
+        d = (int) t;
+        TM1637_display_digit(pos++, d);
+        d = (t - d) * 10.0 + 0.5;
+        // position 2
+        TM1637_display_digit(pos++, d);
+        // position 3 (outer right)
+        if (unit == 'C') {
+            TM1637_display_segments(pos, 0x39);
+        } else if (unit == 'F') {
+            TM1637_display_segments(pos, 0x71);
+        }
+    } else {
+        TM1637_clear();
+        char *msg = (char *) calloc(30, sizeof (char));
+        sprintf(msg, "Error_%d_%3d_Error", (int) t, (int) ((t - (int) t)*100));
+        TM1637_display_text(msg);
+        free(msg);
+    }
+}

--- a/examples/attiny13/main.c
+++ b/examples/attiny13/main.c
@@ -32,27 +32,26 @@ void displayInAllSegments(uint8_t segment);
 void displayTemperature(float t, const char unit);
 
 int
-main(void)
-{
-	uint8_t j = 0;
+main(void) {
+    uint8_t j = 0;
 
-	/* setup */
-	TM1637_init(PB0, PB1);
+    /* setup */
+    TM1637_init(PB0, PB1);
 
-	/* loop */
+    /* loop */
     while (1) {
         // This is ATtiny13 "Running Digits" example using attiny-tm1637-library,
-        for (uint8_t i=0; i<200; i++) {
-		    TM1637_display_digit(TM1637_SET_ADR_00H, i % 0x10);
-		    TM1637_display_digit(TM1637_SET_ADR_01H, (i + 1) % 0x10);
-		    TM1637_display_digit(TM1637_SET_ADR_02H, (i + 2) % 0x10);
-		    TM1637_display_digit(TM1637_SET_ADR_03H, (i + 3) % 0x10);
-		    TM1637_display_colon(true);
-		    _delay_ms(200);
-		    TM1637_display_colon(false);
-		    _delay_ms(200);
-		}
-		TM1637_clear();
+        for (uint8_t i = 0; i < 200; i++) {
+            TM1637_display_digit(TM1637_SET_ADR_00H, i % 0x10);
+            TM1637_display_digit(TM1637_SET_ADR_01H, (i + 1) % 0x10);
+            TM1637_display_digit(TM1637_SET_ADR_02H, (i + 2) % 0x10);
+            TM1637_display_digit(TM1637_SET_ADR_03H, (i + 3) % 0x10);
+            TM1637_display_colon(true);
+            _delay_ms(200);
+            TM1637_display_colon(false);
+            _delay_ms(200);
+        }
+        TM1637_clear();
         displayInAllSegments(0x1);
         _delay_ms(200);
         displayInAllSegments(0x40);
@@ -115,21 +114,21 @@ main(void)
         _delay_ms(3000);
     }
 }
-        
+
 void displayInAllSegments(uint8_t segment) {
     TM1637_display_segments(0, segment);
     TM1637_display_segments(1, segment);
     TM1637_display_segments(2, segment);
     TM1637_display_segments(3, segment);
 }
-        
+
 void displayTemperature(float t, const char unit) {
     // range -9.9 degrees Celsius up to 99.9 degress Celsius or Fahrenheit
     if (t >= -9.9 && t <= 99.9) {
         TM1637_display_colon(1);
-        
+
         uint8_t pos = 0;
-        
+
         // position 0 (outer left)
         if (t < 0) {
             TM1637_display_segments(pos++, 0x40);

--- a/tm1637.c
+++ b/tm1637.c
@@ -37,14 +37,14 @@
 #include <util/delay.h>
 #include "tm1637.h"
 
-#define	TM1637_HIGH(pin)	    (PORTB |= _BV(pin))
-#define	TM1637_LOW(pin)		    (PORTB &= ~_BV(pin))
-#define	TM1637_OUTPUT(pin)	    (DDRB |= _BV(pin))
-#define	TM1637_INPUT(pin)	    (DDRB &= ~_BV(pin))
-#define	TM1637_READ(pin) 	    (((PINB & _BV(pin)) > 0) ? 1 : 0)
+#define TM1637_HIGH(pin)        (PORTB |= _BV(pin))
+#define TM1637_LOW(pin)         (PORTB &= ~_BV(pin))
+#define TM1637_OUTPUT(pin)      (DDRB |= _BV(pin))
+#define TM1637_INPUT(pin)       (DDRB &= ~_BV(pin))
+#define TM1637_READ(pin)        (((PINB & _BV(pin)) > 0) ? 1 : 0)
 
-#define	TM1637_FLAG_ENABLED		(1 << 0)
-#define	TM1637_FLAG_SHOWCOLON	(1 << 1)
+#define TM1637_FLAG_ENABLED     (1 << 0)
+#define TM1637_FLAG_SHOWCOLON   (1 << 1)
 
 #define ASCII_0                 48
 #define ASCII_9                 57
@@ -56,18 +56,17 @@ static void TM1637_stop(void);
 static uint8_t TM1637_write_byte(uint8_t value);
 static uint8_t convertChar(char c);
 
-static const uint8_t _digit2segments[] =
-{
-	0x3F, // 0
-	0x06, // 1
-	0x5B, // 2
-	0x4F, // 3
-	0x66, // 4
-	0x6D, // 5
-	0x7D, // 6
-	0x07, // 7
-	0x7F, // 8
-	0x6F  // 9
+static const uint8_t _digit2segments[] = {
+    0x3F, // 0
+    0x06, // 1
+    0x5B, // 2
+    0x4F, // 3
+    0x66, // 4
+    0x6D, // 5
+    0x7D, // 6
+    0x07, // 7
+    0x7F, // 8
+    0x6F // 9
 };
 
 static uint8_t displayedSegments[4] = {0, 0, 0, 0};
@@ -79,17 +78,16 @@ static uint8_t dio = TM1637_DIO_PIN;
 static uint8_t clk = TM1637_CLK_PIN;
 
 void
-TM1637_init(const uint8_t dioPin, const uint8_t clkPin)
-{
+TM1637_init(const uint8_t dioPin, const uint8_t clkPin) {
     dio = dioPin;
     clk = clkPin;
 
     displayedSegments[0] = displayedSegments[1] = displayedSegments[2] = displayedSegments[3] = 0;
 
     // make both pins output pins thereby implicitely set their level to high
-	DDRB |= (_BV(dio)|_BV(clk));
-	_flags |= TM1637_FLAG_ENABLED;
-	TM1637_clear();
+    DDRB |= (_BV(dio) | _BV(clk));
+    _flags |= TM1637_FLAG_ENABLED;
+    TM1637_clear();
 }
 
 void TM1637_display_text(const char* text) {
@@ -166,54 +164,49 @@ static uint8_t convertChar(char c) {
 }
 
 void
-TM1637_display_digit(const uint8_t addr, const uint8_t digit)
-{
+TM1637_display_digit(const uint8_t addr, const uint8_t digit) {
     TM1637_display_segments(addr % 4, digit < 10 ? _digit2segments[digit] : 0x00);
 }
 
 void
-TM1637_display_segments(const uint8_t addr, const uint8_t segments)
-{
+TM1637_display_segments(const uint8_t addr, const uint8_t segments) {
     if (displayedSegments[addr] != segments) {
         displayedSegments[addr] = segments;
-	    TM1637_cmd(TM1637_CMD_SET_DATA | TM1637_SET_DATA_F_ADDR);
-	    TM1637_start();
-	    TM1637_write_byte(TM1637_CMD_SET_ADDR | addr);
-	    TM1637_write_byte(_flags & TM1637_FLAG_SHOWCOLON ? 0x80 | segments : segments);
-	    TM1637_stop();
-	}
-	TM1637_configure();	
+        TM1637_cmd(TM1637_CMD_SET_DATA | TM1637_SET_DATA_F_ADDR);
+        TM1637_start();
+        TM1637_write_byte(TM1637_CMD_SET_ADDR | addr);
+        TM1637_write_byte(_flags & TM1637_FLAG_SHOWCOLON ? 0x80 | segments : segments);
+        TM1637_stop();
+    }
+    TM1637_configure();
 }
 
 void
-TM1637_display_colon(bool value)
-{
-	if (value) {
-		_flags |= TM1637_FLAG_SHOWCOLON;
+TM1637_display_colon(bool value) {
+    if (value) {
+        _flags |= TM1637_FLAG_SHOWCOLON;
         // explicitely switch on colon to overcome filter in TM1637_display_segments
         TM1637_display_segments(1, 0x80 | displayedSegments[1]);
-	} else {
-		_flags &= ~TM1637_FLAG_SHOWCOLON;
+    } else {
+        _flags &= ~TM1637_FLAG_SHOWCOLON;
         // explicitely switch off colon to overcome filter in TM1637_display_segments
         TM1637_display_segments(1, ~0x80 & displayedSegments[1]);
-	}
+    }
 }
 
 void
-TM1637_clear(void)
-{
-	TM1637_display_colon(false);
-	TM1637_display_segments(TM1637_SET_ADR_00H, 0x00); // also sets displayedSegments[0] to 0
-	TM1637_display_segments(TM1637_SET_ADR_01H, 0x00); // also sets displayedSegments[1] to 0
-	TM1637_display_segments(TM1637_SET_ADR_02H, 0x00); // also sets displayedSegments[2] to 0
-	TM1637_display_segments(TM1637_SET_ADR_03H, 0x00); // also sets displayedSegments[3] to 0
+TM1637_clear(void) {
+    TM1637_display_colon(false);
+    TM1637_display_segments(TM1637_SET_ADR_00H, 0x00); // also sets displayedSegments[0] to 0
+    TM1637_display_segments(TM1637_SET_ADR_01H, 0x00); // also sets displayedSegments[1] to 0
+    TM1637_display_segments(TM1637_SET_ADR_02H, 0x00); // also sets displayedSegments[2] to 0
+    TM1637_display_segments(TM1637_SET_ADR_03H, 0x00); // also sets displayedSegments[3] to 0
 }
 
 void
-TM1637_set_brightness(const uint8_t brightness)
-{
-	_brightness = brightness & 0x07;
-	TM1637_configure();
+TM1637_set_brightness(const uint8_t brightness) {
+    _brightness = brightness & 0x07;
+    TM1637_configure();
 }
 
 void TM1637_display_on(void) {
@@ -225,94 +218,87 @@ void TM1637_display_off(void) {
 }
 
 void
-TM1637_enable(bool value)
-{
-	if (value) {
-		_flags |= TM1637_FLAG_ENABLED;
-	} else {
-		_flags &= ~TM1637_FLAG_ENABLED;
-	}
-	TM1637_configure();
+TM1637_enable(bool value) {
+    if (value) {
+        _flags |= TM1637_FLAG_ENABLED;
+    } else {
+        _flags &= ~TM1637_FLAG_ENABLED;
+    }
+    TM1637_configure();
 }
 
 void
-TM1637_configure(void)
-{
-	uint8_t cmd = TM1637_CMD_SET_DISPLAY;
-	cmd |= _brightness;
-	if (_flags & TM1637_FLAG_ENABLED) {
-		cmd |= TM1637_SET_DISPLAY_ON;
-	}
-	TM1637_cmd(cmd);
+TM1637_configure(void) {
+    uint8_t cmd = TM1637_CMD_SET_DISPLAY;
+    cmd |= _brightness;
+    if (_flags & TM1637_FLAG_ENABLED) {
+        cmd |= TM1637_SET_DISPLAY_ON;
+    }
+    TM1637_cmd(cmd);
 }
 
 void
-TM1637_cmd(uint8_t value)
-{
-	TM1637_start();
-	TM1637_write_byte(value);
-	TM1637_stop();
+TM1637_cmd(uint8_t value) {
+    TM1637_start();
+    TM1637_write_byte(value);
+    TM1637_stop();
 }
 
 void
-TM1637_start(void)
-{
+TM1637_start(void) {
     /*
      * When CLK is high, and DIO goes from high to low, input begins
      */
     PORTB |= _BV(clk) | _BV(dio);
-	_delay_us(TM1637_DELAY_US);
-	TM1637_LOW(dio);
+    _delay_us(TM1637_DELAY_US);
+    TM1637_LOW(dio);
 }
 
 void
-TM1637_stop(void)
-{
+TM1637_stop(void) {
     /*
      * When CLK is high, and DIO goes from low to high, input ends
      */
-	TM1637_LOW(clk);
-	_delay_us(TM1637_DELAY_US);
-	TM1637_LOW(dio);
-	_delay_us(TM1637_DELAY_US);
-	TM1637_HIGH(clk);
-	_delay_us(TM1637_DELAY_US);
-	TM1637_HIGH(dio);
+    TM1637_LOW(clk);
+    _delay_us(TM1637_DELAY_US);
+    TM1637_LOW(dio);
+    _delay_us(TM1637_DELAY_US);
+    TM1637_HIGH(clk);
+    _delay_us(TM1637_DELAY_US);
+    TM1637_HIGH(dio);
 }
 
 uint8_t
-TM1637_write_byte(uint8_t value)
-{
+TM1637_write_byte(uint8_t value) {
     /*
      *Send each bit of data
      */
-	for (uint8_t i = 0; i < 8; i++) {
-	    //transfer data when clock is low, from low bit to high bit
-		TM1637_LOW(clk);
-		if ((value >> i) & 0x01) {
-			TM1637_HIGH(dio);  // data bit equals 1
-		} else {
-			TM1637_LOW(dio);   // data bit equals 0
-		}
-		_delay_us(TM1637_DELAY_US);
-		TM1637_HIGH(clk);
-		_delay_us(TM1637_DELAY_US);
-	}
+    for (uint8_t i = 0; i < 8; i++) {
+        //transfer data when clock is low, from low bit to high bit
+        TM1637_LOW(clk);
+        if ((value >> i) & 0x01) {
+            TM1637_HIGH(dio); // data bit equals 1
+        } else {
+            TM1637_LOW(dio); // data bit equals 0
+        }
+        _delay_us(TM1637_DELAY_US);
+        TM1637_HIGH(clk);
+        _delay_us(TM1637_DELAY_US);
+    }
     /*
      * End of 8th clock cycle is start of ACK from TM1637
      */
-	TM1637_LOW(clk);
-	_delay_us(TM1637_DELAY_US);
+    TM1637_LOW(clk);
+    _delay_us(TM1637_DELAY_US);
 
-	uint8_t ack = TM1637_READ(dio);
+    uint8_t ack = TM1637_READ(dio);
 
-	_delay_us(TM1637_DELAY_US);
+    _delay_us(TM1637_DELAY_US);
 
-	TM1637_HIGH(clk);
-	_delay_us(TM1637_DELAY_US);
+    TM1637_HIGH(clk);
+    _delay_us(TM1637_DELAY_US);
 
-	TM1637_LOW(clk);
+    TM1637_LOW(clk);
 
-	return ack;
+    return ack;
 }
-

--- a/tm1637.c
+++ b/tm1637.c
@@ -84,7 +84,7 @@ TM1637_init(const uint8_t dioPin, const uint8_t clkPin) {
 
     displayedSegments[0] = displayedSegments[1] = displayedSegments[2] = displayedSegments[3] = 0;
 
-    // make both pins output pins thereby implicitely set their level to high
+    // make both pins output pins thereby implicitly set their level to high
     DDRB |= (_BV(dio) | _BV(clk));
     _flags |= TM1637_FLAG_ENABLED;
     TM1637_clear();
@@ -98,7 +98,7 @@ void TM1637_display_text(const char* text) {
 
     uint8_t segment[4] = {0, 0, 0, 0};
     for (uint8_t i = 0; i < l; i++) {
-        for (uint8_t j = 0; j < 4; j++) TM1637_display_segments(j, j != 1 ? segment[j] : displayColon | segment[j]);
+        for (uint8_t j = 0; j < 4; j++) TM1637_display_segments(j, displayColon | segment[j]);
         segment[0] = segment[1];
         segment[1] = segment[2];
         segment[2] = segment[3];
@@ -185,11 +185,11 @@ void
 TM1637_display_colon(bool value) {
     if (value) {
         _flags |= TM1637_FLAG_SHOWCOLON;
-        // explicitely switch on colon to overcome filter in TM1637_display_segments
+        // explicitly switch on colon to overcome filter in TM1637_display_segments
         TM1637_display_segments(1, 0x80 | displayedSegments[1]);
     } else {
         _flags &= ~TM1637_FLAG_SHOWCOLON;
-        // explicitely switch off colon to overcome filter in TM1637_display_segments
+        // explicitly switch off colon to overcome filter in TM1637_display_segments
         TM1637_display_segments(1, ~0x80 & displayedSegments[1]);
     }
 }
@@ -289,6 +289,7 @@ TM1637_write_byte(uint8_t value) {
      * End of 8th clock cycle is start of ACK from TM1637
      */
     TM1637_LOW(clk);
+    TM1637_INPUT(dio);
     _delay_us(TM1637_DELAY_US);
 
     uint8_t ack = TM1637_READ(dio);
@@ -299,6 +300,7 @@ TM1637_write_byte(uint8_t value) {
     _delay_us(TM1637_DELAY_US);
 
     TM1637_LOW(clk);
+    TM1637_OUTPUT(dio);
 
     return ack;
 }

--- a/tm1637.c
+++ b/tm1637.c
@@ -1,5 +1,19 @@
+/* Copyright (c) 2017-2018, Łukasz Marcin Podkalicki <lpodkalicki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
- * Copyright (c) 2017, Łukasz Marcin Podkalicki <lpodkalicki@gmail.com>
  * 
  * This is ATtiny13/25/45/85 library for 4-Digit LED Display based on TM1637 chip.
  *
@@ -14,29 +28,33 @@
  * - library: https://github.com/lpodkalicki/attiny-tm1637-library
  * - documentation: https://github.com/lpodkalicki/attiny-tm1637-library/README.md
  * - TM1637 datasheet: https://github.com/lpodkalicki/attiny-tm1637-library/blob/master/docs/TM1637_V2.4_EN.pdf
+ * - http://wiki.seeedstudio.com/images/c/c3/TM1637_datasheet.pdf
  */
+
+#define F_CPU 1000000UL
 
 #include <avr/io.h>
 #include <util/delay.h>
 #include "tm1637.h"
 
-#define	TM1637_DIO_HIGH()		(PORTB |= _BV(TM1637_DIO_PIN))
-#define	TM1637_DIO_LOW()		(PORTB &= ~_BV(TM1637_DIO_PIN))
-#define	TM1637_DIO_OUTPUT()		(DDRB |= _BV(TM1637_DIO_PIN))
-#define	TM1637_DIO_INPUT()		(DDRB &= ~_BV(TM1637_DIO_PIN))
-#define	TM1637_DIO_READ() 		(((PINB & _BV(TM1637_DIO_PIN)) > 0) ? 1 : 0)
-#define	TM1637_CLK_HIGH()		(PORTB |= _BV(TM1637_CLK_PIN))
-#define	TM1637_CLK_LOW()		(PORTB &= ~_BV(TM1637_CLK_PIN))
+#define	TM1637_HIGH(pin)	    (PORTB |= _BV(pin))
+#define	TM1637_LOW(pin)		    (PORTB &= ~_BV(pin))
+#define	TM1637_OUTPUT(pin)	    (DDRB |= _BV(pin))
+#define	TM1637_INPUT(pin)	    (DDRB &= ~_BV(pin))
+#define	TM1637_READ(pin) 	    (((PINB & _BV(pin)) > 0) ? 1 : 0)
 
 #define	TM1637_FLAG_ENABLED		(1 << 0)
-#define	TM1637_FLAG_SHOWCOLON		(1 << 1)
+#define	TM1637_FLAG_SHOWCOLON	(1 << 1)
 
+#define ASCII_0                 48
+#define ASCII_9                 57
 
 static void TM1637_configure(void);
 static void TM1637_cmd(uint8_t value);
 static void TM1637_start(void);
 static void TM1637_stop(void);
 static uint8_t TM1637_write_byte(uint8_t value);
+static uint8_t convertChar(char c);
 
 static const uint8_t _digit2segments[] =
 {
@@ -52,82 +70,163 @@ static const uint8_t _digit2segments[] =
 	0x6F  // 9
 };
 
+static uint8_t displayedSegments[4] = {0, 0, 0, 0};
+
 static uint8_t _brightness = TM1637_DEFAULT_BRIGHTNESS;
-static uint8_t _digit = 0xff;
 static uint8_t _flags = 0x00;
 
-void
-TM1637_init(void)
-{
+static uint8_t dio = TM1637_DIO_PIN;
+static uint8_t clk = TM1637_CLK_PIN;
 
-	DDRB |= (_BV(TM1637_DIO_PIN)|_BV(TM1637_CLK_PIN));
-	PORTB &= ~(_BV(TM1637_DIO_PIN)|_BV(TM1637_CLK_PIN));
+void
+TM1637_init(const uint8_t dioPin, const uint8_t clkPin)
+{
+    dio = dioPin;
+    clk = clkPin;
+
+    displayedSegments[0] = displayedSegments[1] = displayedSegments[2] = displayedSegments[3] = 0;
+
+    // make both pins output pins thereby implicitely set their level to high
+	DDRB |= (_BV(dio)|_BV(clk));
 	_flags |= TM1637_FLAG_ENABLED;
 	TM1637_clear();
+}
+
+void TM1637_display_text(const char* text) {
+    uint8_t l = 0;
+    while (text[l++] != '\0');
+
+    uint8_t displayColon = _flags & TM1637_FLAG_SHOWCOLON ? 0x80 : 0x00;
+
+    uint8_t segment[4] = {0, 0, 0, 0};
+    for (uint8_t i = 0; i < l; i++) {
+        for (uint8_t j = 0; j < 4; j++) TM1637_display_segments(j, j != 1 ? segment[j] : displayColon | segment[j]);
+        segment[0] = segment[1];
+        segment[1] = segment[2];
+        segment[2] = segment[3];
+        segment[3] = convertChar(text[i]);
+        _delay_ms(100);
+    }
+}
+
+static uint8_t convertChar(char c) {
+    uint8_t val = 0;
+
+    if ((ASCII_0 <= c) && (c <= ASCII_9)) {
+        return _digit2segments[c - ASCII_0];
+    } else if ('-' == c) {
+        return 0x40;
+    } else if ('_' == c) {
+        return 0x08;
+    } else if ('A' == c) {
+        return 0x77;
+    } else if ('B' == c) {
+        return _digit2segments[8];
+    } else if ('C' == c) {
+        return 0x39;
+    } else if ('D' == c) {
+        return _digit2segments[0];
+    } else if ('E' == c) {
+        return val | 0x79;
+    } else if ('F' == c) {
+        return val | 0x71;
+    } else if ('G' == c) {
+        return _digit2segments[6];
+    } else if ('H' == c) {
+        return 0x76;
+    } else if ('I' == c) {
+        return _digit2segments[1];
+    } else if ('J' == c) {
+        return 0x0F;
+    } else if ('L' == c) {
+        return 0x38;
+    } else if ('O' == c) {
+        return _digit2segments[0];
+    } else if ('P' == c) {
+        return 0x73;
+    } else if ('R' == c) {
+        return _digit2segments[0];
+    } else if ('S' == c) {
+        return 0x6C;
+    } else if ('U' == c) {
+        return 0x3D;
+    } else if ('d' == c) {
+        return 0x5E;
+    } else if ('h' == c) {
+        return 0x74;
+    } else if ('o' == c) {
+        return 0x5C;
+    } else if ('r' == c) {
+        return 0x50;
+    } else if ('u' == c) {
+        return 0x94;
+    }
+
+    return val;
 }
 
 void
 TM1637_display_digit(const uint8_t addr, const uint8_t digit)
 {
-	uint8_t segments = digit < 10 ? _digit2segments[digit] : 0x00;
-
-	if (addr == TM1637_SET_ADR_01H) {
-		_digit = digit;
-		if (_flags & TM1637_FLAG_SHOWCOLON) {
-			segments |= 0x80;
-		}
-	}
-
-	TM1637_display_segments(addr, segments);
+    TM1637_display_segments(addr % 4, digit < 10 ? _digit2segments[digit] : 0x00);
 }
 
 void
 TM1637_display_segments(const uint8_t addr, const uint8_t segments)
 {
-
-	TM1637_cmd(TM1637_CMD_SET_DATA | TM1637_SET_DATA_F_ADDR);
-	TM1637_start();
-	TM1637_write_byte(TM1637_CMD_SET_ADDR | addr);
-	TM1637_write_byte(segments);
-	TM1637_stop();	
+    if (displayedSegments[addr] != segments) {
+        displayedSegments[addr] = segments;
+	    TM1637_cmd(TM1637_CMD_SET_DATA | TM1637_SET_DATA_F_ADDR);
+	    TM1637_start();
+	    TM1637_write_byte(TM1637_CMD_SET_ADDR | addr);
+	    TM1637_write_byte(_flags & TM1637_FLAG_SHOWCOLON ? 0x80 | segments : segments);
+	    TM1637_stop();
+	}
 	TM1637_configure();	
 }
 
 void
 TM1637_display_colon(bool value)
 {
-
 	if (value) {
 		_flags |= TM1637_FLAG_SHOWCOLON;
+        // explicitely switch on colon to overcome filter in TM1637_display_segments
+        TM1637_display_segments(1, 0x80 | displayedSegments[1]);
 	} else {
 		_flags &= ~TM1637_FLAG_SHOWCOLON;
+        // explicitely switch off colon to overcome filter in TM1637_display_segments
+        TM1637_display_segments(1, ~0x80 & displayedSegments[1]);
 	}
-	TM1637_display_digit(TM1637_SET_ADR_01H, _digit);
 }
 
 void
 TM1637_clear(void)
-{	
-
+{
 	TM1637_display_colon(false);
-	TM1637_display_segments(TM1637_SET_ADR_00H, 0x00);
-	TM1637_display_segments(TM1637_SET_ADR_01H, 0x00);
-	TM1637_display_segments(TM1637_SET_ADR_02H, 0x00);
-	TM1637_display_segments(TM1637_SET_ADR_03H, 0x00);
+	TM1637_display_segments(TM1637_SET_ADR_00H, 0x00); // also sets displayedSegments[0] to 0
+	TM1637_display_segments(TM1637_SET_ADR_01H, 0x00); // also sets displayedSegments[1] to 0
+	TM1637_display_segments(TM1637_SET_ADR_02H, 0x00); // also sets displayedSegments[2] to 0
+	TM1637_display_segments(TM1637_SET_ADR_03H, 0x00); // also sets displayedSegments[3] to 0
 }
 
 void
 TM1637_set_brightness(const uint8_t brightness)
 {
-
 	_brightness = brightness & 0x07;
 	TM1637_configure();
+}
+
+void TM1637_display_on(void) {
+    TM1637_enable(true);
+}
+
+void TM1637_display_off(void) {
+    TM1637_enable(false);
 }
 
 void
 TM1637_enable(bool value)
 {
-
 	if (value) {
 		_flags |= TM1637_FLAG_ENABLED;
 	} else {
@@ -139,21 +238,17 @@ TM1637_enable(bool value)
 void
 TM1637_configure(void)
 {
-	uint8_t cmd;
-
-	cmd = TM1637_CMD_SET_DSIPLAY;
+	uint8_t cmd = TM1637_CMD_SET_DISPLAY;
 	cmd |= _brightness;
 	if (_flags & TM1637_FLAG_ENABLED) {
 		cmd |= TM1637_SET_DISPLAY_ON;
 	}
-
 	TM1637_cmd(cmd);
 }
 
 void
 TM1637_cmd(uint8_t value)
 {
-
 	TM1637_start();
 	TM1637_write_byte(value);
 	TM1637_stop();
@@ -162,67 +257,61 @@ TM1637_cmd(uint8_t value)
 void
 TM1637_start(void)
 {
-
-	TM1637_DIO_HIGH();
-	TM1637_CLK_HIGH();
+    /*
+     * When CLK is high, and DIO goes from high to low, input begins
+     */
+    PORTB |= _BV(clk) | _BV(dio);
 	_delay_us(TM1637_DELAY_US);
-	TM1637_DIO_LOW();
+	TM1637_LOW(dio);
 }
 
 void
 TM1637_stop(void)
 {
-
-	TM1637_CLK_LOW();
+    /*
+     * When CLK is high, and DIO goes from low to high, input ends
+     */
+	TM1637_LOW(clk);
 	_delay_us(TM1637_DELAY_US);
-
-	TM1637_DIO_LOW();
+	TM1637_LOW(dio);
 	_delay_us(TM1637_DELAY_US);
-
-	TM1637_CLK_HIGH();
+	TM1637_HIGH(clk);
 	_delay_us(TM1637_DELAY_US);
-
-	TM1637_DIO_HIGH();
+	TM1637_HIGH(dio);
 }
 
 uint8_t
 TM1637_write_byte(uint8_t value)
 {
-	uint8_t i, ack;
-
-	for (i = 0; i < 8; ++i, value >>= 1) {
-		TM1637_CLK_LOW();
-		_delay_us(TM1637_DELAY_US);
-
-		if (value & 0x01) {
-			TM1637_DIO_HIGH();
+    /*
+     *Send each bit of data
+     */
+	for (uint8_t i = 0; i < 8; i++) {
+	    //transfer data when clock is low, from low bit to high bit
+		TM1637_LOW(clk);
+		if ((value >> i) & 0x01) {
+			TM1637_HIGH(dio);  // data bit equals 1
 		} else {
-			TM1637_DIO_LOW();
+			TM1637_LOW(dio);   // data bit equals 0
 		}
-
-		TM1637_CLK_HIGH();
+		_delay_us(TM1637_DELAY_US);
+		TM1637_HIGH(clk);
 		_delay_us(TM1637_DELAY_US);
 	}
-
-	TM1637_CLK_LOW();
-	TM1637_DIO_INPUT();
-	TM1637_DIO_HIGH();
+    /*
+     * End of 8th clock cycle is start of ACK from TM1637
+     */
+	TM1637_LOW(clk);
 	_delay_us(TM1637_DELAY_US);
 
-	ack = TM1637_DIO_READ();
-	if (ack) {
-		TM1637_DIO_OUTPUT();
-		TM1637_DIO_LOW();
-	}
+	uint8_t ack = TM1637_READ(dio);
+
 	_delay_us(TM1637_DELAY_US);
 
-	TM1637_CLK_HIGH();
+	TM1637_HIGH(clk);
 	_delay_us(TM1637_DELAY_US);
 
-	TM1637_CLK_LOW();
-	_delay_us(TM1637_DELAY_US);
-
-	TM1637_DIO_OUTPUT();
+	TM1637_LOW(clk);
 
 	return ack;
 }

--- a/tm1637.h
+++ b/tm1637.h
@@ -1,6 +1,19 @@
+/* Copyright (c) 2017-2018, Łukasz Marcin Podkalicki <lpodkalicki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
- * Copyright (c) 2017, Łukasz Marcin Podkalicki <lpodkalicki@gmail.com>
- * 
  * This is ATtiny13/25/45/85 library for 4-Digit LED Display based on TM1637 chip.
  *
  * Features:
@@ -14,6 +27,7 @@
  * - library: https://github.com/lpodkalicki/attiny-tm1637-library
  * - documentation: https://github.com/lpodkalicki/attiny-tm1637-library/README.md
  * - TM1637 datasheet: https://github.com/lpodkalicki/attiny-tm1637-library/blob/master/docs/TM1637_V2.4_EN.pdf
+ * - http://wiki.seeedstudio.com/images/c/c3/TM1637_datasheet.pdf
  */
 
 #ifndef	_ATTINY_TM1637_H_
@@ -23,15 +37,15 @@
 #include <stdbool.h>
 
 // Main Settings
-#define	TM1637_DIO_PIN			PB0
-#define	TM1637_CLK_PIN			PB1
-#define	TM1637_DELAY_US			(50)
+#define	TM1637_DIO_PIN			    PB0
+#define	TM1637_CLK_PIN			    PB1
+#define	TM1637_DELAY_US			    (3)
 #define	TM1637_DEFAULT_BRIGHTNESS	(7)
 
 // TM1637 commands
-#define	TM1637_CMD_SET_DATA		0x40
-#define	TM1637_CMD_SET_ADDR		0xC0
-#define	TM1637_CMD_SET_DSIPLAY		0x80
+#define	TM1637_CMD_SET_DATA		    0x40
+#define	TM1637_CMD_SET_ADDR		    0xC0
+#define	TM1637_CMD_SET_DISPLAY		0x80
 
 // TM1637 data settings (use bitwise OR to contruct complete command)
 #define	TM1637_SET_DATA_WRITE		0x00 // write data to the display register
@@ -42,10 +56,10 @@
 #define	TM1637_SET_DATA_M_TEST		0x10 // test mode
 
 // TM1637 address settings (use bitwise OR to contruct complete command)
-#define	TM1637_SET_ADR_00H		0x00 // address 00
-#define	TM1637_SET_ADR_01H		0x01 // address 01
-#define	TM1637_SET_ADR_02H		0x02 // address 02
-#define	TM1637_SET_ADR_03H		0x03 // address 03
+#define	TM1637_SET_ADR_00H		    0x00 // address 00
+#define	TM1637_SET_ADR_01H		    0x01 // address 01
+#define	TM1637_SET_ADR_02H		    0x02 // address 02
+#define	TM1637_SET_ADR_03H		    0x03 // address 03
 
 // TM1637 display control command set (use bitwise OR to consruct complete command)
 #define	TM1637_SET_DISPLAY_OFF		0x00 // off
@@ -54,10 +68,18 @@
 
 /**
  * Initialize TM1637 display driver.
- * Clock pin (TM1637_CLK_PIN) and data pin (TM1637_DIO_PIN) 
+ * Clock pin and data pin, e.g. TM1637_init(PB0, PB1)
  * are defined at the top of this file.
  */
-void TM1637_init(void);
+void TM1637_init(const uint8_t dioPin, const uint8_t clkPin);
+
+/**
+ * Display text. If the text length exceeds 4 characters the text is
+ * scrolled from left to right. The characters which can be displayed
+ * are limited to what can be represented by the physically segments.
+ * Example: TM1637_display_text("Error");
+ */
+void TM1637_display_text(const char* text);
 
 /**
  * Display digits ('0'..'9') at positions (0x00..0x03)
@@ -101,6 +123,18 @@ void TM1637_clear(void);
  * Max brightness: 7
  */
 void TM1637_set_brightness(const uint8_t brightness);
+
+/**
+ * Turn display on.
+ * Short form of TM1637_enable(true)
+ */
+void TM1637_display_on(void);
+
+/**
+ * Turn display off.
+ * Short form of TM1637_enable(false)
+ */
+void TM1637_display_off(void);
 
 /**
  * Turn display on/off.

--- a/tm1637.h
+++ b/tm1637.h
@@ -30,40 +30,40 @@
  * - http://wiki.seeedstudio.com/images/c/c3/TM1637_datasheet.pdf
  */
 
-#ifndef	_ATTINY_TM1637_H_
-#define	_ATTINY_TM1637_H_
+#ifndef _ATTINY_TM1637_H_
+#define _ATTINY_TM1637_H_
 
 #include <stdint.h>
 #include <stdbool.h>
 
 // Main Settings
-#define	TM1637_DIO_PIN			    PB0
-#define	TM1637_CLK_PIN			    PB1
-#define	TM1637_DELAY_US			    (3)
-#define	TM1637_DEFAULT_BRIGHTNESS	(7)
+#define TM1637_DIO_PIN       PB0
+#define TM1637_CLK_PIN       PB1
+#define TM1637_DELAY_US       (3)
+#define TM1637_DEFAULT_BRIGHTNESS (7)
 
 // TM1637 commands
-#define	TM1637_CMD_SET_DATA		    0x40
-#define	TM1637_CMD_SET_ADDR		    0xC0
-#define	TM1637_CMD_SET_DISPLAY		0x80
+#define TM1637_CMD_SET_DATA      0x40
+#define TM1637_CMD_SET_ADDR      0xC0
+#define TM1637_CMD_SET_DISPLAY  0x80
 
 // TM1637 data settings (use bitwise OR to contruct complete command)
-#define	TM1637_SET_DATA_WRITE		0x00 // write data to the display register
-#define	TM1637_SET_DATA_READ		0x02 // read the key scan data
-#define	TM1637_SET_DATA_A_ADDR		0x00 // automatic address increment
-#define	TM1637_SET_DATA_F_ADDR		0x04 // fixed address
-#define	TM1637_SET_DATA_M_NORM		0x00 // normal mode
-#define	TM1637_SET_DATA_M_TEST		0x10 // test mode
+#define TM1637_SET_DATA_WRITE  0x00 // write data to the display register
+#define TM1637_SET_DATA_READ  0x02 // read the key scan data
+#define TM1637_SET_DATA_A_ADDR  0x00 // automatic address increment
+#define TM1637_SET_DATA_F_ADDR  0x04 // fixed address
+#define TM1637_SET_DATA_M_NORM  0x00 // normal mode
+#define TM1637_SET_DATA_M_TEST  0x10 // test mode
 
 // TM1637 address settings (use bitwise OR to contruct complete command)
-#define	TM1637_SET_ADR_00H		    0x00 // address 00
-#define	TM1637_SET_ADR_01H		    0x01 // address 01
-#define	TM1637_SET_ADR_02H		    0x02 // address 02
-#define	TM1637_SET_ADR_03H		    0x03 // address 03
+#define TM1637_SET_ADR_00H      0x00 // address 00
+#define TM1637_SET_ADR_01H      0x01 // address 01
+#define TM1637_SET_ADR_02H      0x02 // address 02
+#define TM1637_SET_ADR_03H      0x03 // address 03
 
 // TM1637 display control command set (use bitwise OR to consruct complete command)
-#define	TM1637_SET_DISPLAY_OFF		0x00 // off
-#define	TM1637_SET_DISPLAY_ON		0x08 // on
+#define TM1637_SET_DISPLAY_OFF  0x00 // off
+#define TM1637_SET_DISPLAY_ON  0x08 // on
 
 
 /**
@@ -88,7 +88,7 @@ void TM1637_display_digit(const uint8_t addr, const uint8_t digit);
 
 /**
  * Display raw segments at positions (0x00..0x03)
- * 
+ *
  *      bits:                 hex:
  *        -- 0 --               -- 01 --
  *       |       |             |        |
@@ -141,5 +141,5 @@ void TM1637_display_off(void);
  */
 void TM1637_enable(const bool value);
 
-#endif	/* !_ATTINY_TM1637_H_ */
+#endif /* !_ATTINY_TM1637_H_ */
 


### PR DESCRIPTION
proposals for minor changes and small enhancements

changes:
- added Apache licence 
- dio pin and clk pin are set via TM1637_init method
- setting data direction in init method implicitly sets pin high, therefore explicit raising level for dio pin and clk pin is dropped
- only changed segments are sent to the sensor device (see TM1637_display_segments)
- acknowledge in tm1637_write_byte modified
- _delay_us set to 3 microseconds in tm1637.h (see http://wiki.seeedstudio.com/images/c/c3/TM1637_datasheet.pdf) 

enhancements:
- added TM1637_display_text for display text scrolled from right to left
- added TM1637_display_on as short form of TM1637_enable(true)
- added TM1637_display_off as short form of TM1637_enable(false)
- added some usage examples in main.c
